### PR TITLE
disabling embedded DEPENDENCY_INFO_BLOCK blob

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,12 @@ android {
         compose true
         buildConfig true
     }
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
     signingConfigs {
         release {
             storeFile file(PRIVATE_DNS_QS_RELEASE_STORE_FILE)


### PR DESCRIPTION
Our scanners yielded

    ! repo/com.flashsphere.privatednsqs_23.apk contains signature block blobs: 0x504b4453 (DEPENDENCY_INFO_BLOCK; GOOGLE)

This PR disables the embedded blob.

For some background: that BLOB is supposed to be just a binary representation of your app's dependency tree. But as it's encrypted with a public key belonging to Google, only Google can read it – and nobody else can even verify what it really contains. More details can be found e.g. here: [Ramping up security: additional APK checks are in place with the IzzyOnDroid repo](https://android.izzysoft.de/articles/named/iod-scan-apkchecks#blobs).